### PR TITLE
KiCad version and json output format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           kicad_sch: test/test.kicad_sch
           sch_erc: true
-          output_format: json
+          report_format: json
           sch_erc_file: erc.json
 
       - name: Run KiCad DRC

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,13 +31,15 @@ jobs:
             ${{ github.workspace }}/test/bom.csv
             ${{ github.workspace }}/test/gbr.zip
 
-      - name: Run KiCad ERC
+      - name: Run KiCad ERC with a json output format
         id: erc
         uses: ./
         if: '!cancelled()'
         with:
           kicad_sch: test/test.kicad_sch
           sch_erc: true
+          output_format: json
+          sch_erc_file: erc.json
 
       - name: Run KiCad DRC
         id: drc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kicad/kicad:8.0.2
+FROM kicad/kicad:8.0
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -82,28 +82,30 @@ See this example working in the action runs of this repository.
 
 ## Configuration
 
-| Option             | Description                            | Default   |
-|--------------------|----------------------------------------|-----------|
-| `kicad_sch`        | Path to `.kicad_sch` file              |           |
-| `sch_erc`          | Whether to run ERC on the schematic    | `false`   |
-| `sch_erc_file`     | Output filename of ERC report          | `erc.rpt` |
-| `sch_pdf`          | Whether to generate PDF from schematic | `false`   |
-| `sch_pdf_file`     | Output filename of PDF schematic       | `sch.pdf` |
-| `sch_bom`          | Whether to generate BOM from schematic | `false`   |
-| `sch_bom_file`     | Output filename of BOM                 | `bom.csv` |
-| `sch_bom_preset`   | Name of a BOM preset setting to use    |           |
-|                    |                                        |           |
-| `kicad_pcb`        | Path to `.kicad_pcb` file              |           |
-| `pcb_drc`          | Whether to run DRC on the PCB          | `false`   |
-| `pcb_drc_file`     | Output filename for DRC report         | `drc.rpt` |
-| `pcb_gerbers`      | Whether to generate Gerbers from PCB   | `false`   |
-| `pcb_gerbers_file` | Output filename of Gerbers             | `gbr.zip` |
+| Option             | Description                                     | Default   |
+|--------------------|-------------------------------------------------|-----------|
+| `kicad_sch`        | Path to `.kicad_sch` file                       |           |
+| `sch_erc`          | Whether to run ERC on the schematic             | `false`   |
+| `sch_erc_file`     | Output filename of ERC report                   | `erc.rpt` |
+| `sch_pdf`          | Whether to generate PDF from schematic          | `false`   |
+| `sch_pdf_file`     | Output filename of PDF schematic                | `sch.pdf` |
+| `sch_bom`          | Whether to generate BOM from schematic          | `false`   |
+| `sch_bom_file`     | Output filename of BOM                          | `bom.csv` |
+| `sch_bom_preset`   | Name of a BOM preset setting to use             |           |
+| `output_format`    | ERC/DRC report file format (`json` or `report`) | `report`  |
+|                    |                                                 |           |
+| `kicad_pcb`        | Path to `.kicad_pcb` file                       |           |
+| `pcb_drc`          | Whether to run DRC on the PCB                   | `false`   |
+| `pcb_drc_file`     | Output filename for DRC report                  | `drc.rpt` |
+| `pcb_gerbers`      | Whether to generate Gerbers from PCB            | `false`   |
+| `pcb_gerbers_file` | Output filename of Gerbers                      | `gbr.zip` |
 
 ## Roadmap
 
 - [ ] Add support for more configuration options, e.g. BOM format or Gerber layers
 - [ ] Add a way to specify KiCad version to use
 - [ ] Better detect if steps of this action fail
+- [ ] Find a better way to enforce the default output files extensions depending on the format requesed
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See this example working in the action runs of this repository.
 | `sch_bom`          | Whether to generate BOM from schematic          | `false`   |
 | `sch_bom_file`     | Output filename of BOM                          | `bom.csv` |
 | `sch_bom_preset`   | Name of a BOM preset setting to use             |           |
-| `output_format`    | ERC/DRC report file format (`json` or `report`) | `report`  |
+| `report_format`    | ERC/DRC report file format (`json` or `report`) | `report`  |
 |                    |                                                 |           |
 | `kicad_pcb`        | Path to `.kicad_pcb` file                       |           |
 | `pcb_drc`          | Whether to run DRC on the PCB                   | `false`   |

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,13 @@ inputs:
   sch_bom_preset:
     description: 'Name of a BOM preset setting to use'
     default: ''
+  output_format:
+    description: 'ERC and DRC report files format'
+    type: choice
+    options:
+      - json
+      - report
+    default: 'report'
 
   kicad_pcb:
     description: 'Path to .kicad_pcb file'

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   sch_bom_preset:
     description: 'Name of a BOM preset setting to use'
     default: ''
-  output_format:
+  report_format:
     description: 'ERC and DRC report files format'
     type: choice
     options:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ if [[ -n $INPUT_KICAD_SCH ]] && [[ $INPUT_SCH_ERC = "true" ]]
 then
   kicad-cli sch erc \
     --output "`dirname $INPUT_KICAD_SCH`/$INPUT_SCH_ERC_FILE" \
-    --format $INPUT_OUTPUT_FORMAT \
+    --format $INPUT_REPORT_FORMAT \
     --exit-code-violations \
     "$INPUT_KICAD_SCH"
   erc_violation=$?
@@ -39,7 +39,7 @@ if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_DRC = "true" ]]
 then
   kicad-cli pcb drc \
     --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_DRC_FILE" \
-    --format $INPUT_OUTPUT_FORMAT \
+    --format $INPUT_REPORT_FORMAT \
     --exit-code-violations \
     "$INPUT_KICAD_PCB"
   drc_violation=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ if [[ -n $INPUT_KICAD_SCH ]] && [[ $INPUT_SCH_ERC = "true" ]]
 then
   kicad-cli sch erc \
     --output "`dirname $INPUT_KICAD_SCH`/$INPUT_SCH_ERC_FILE" \
+    --format $INPUT_OUTPUT_FORMAT \
     --exit-code-violations \
     "$INPUT_KICAD_SCH"
   erc_violation=$?
@@ -38,6 +39,7 @@ if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_DRC = "true" ]]
 then
   kicad-cli pcb drc \
     --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_DRC_FILE" \
+    --format $INPUT_OUTPUT_FORMAT \
     --exit-code-violations \
     "$INPUT_KICAD_PCB"
   drc_violation=$?


### PR DESCRIPTION
- Use KiCad's latest 8.0 version in the docker file

- Added a `report_format` action input to select between `json` and `report`. This will create a report file with either `*.json` or `*.rpt` extensions