### PR TITLE
Add raytraced image output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,3 +64,15 @@ jobs:
         with:
           name: drc.rpt
           path: ${{ github.workspace }}/test/drc.rpt
+
+      - name: Generate rendered images
+        uses: ./
+        with:
+          kicad_pcb: test/test.kicad_pcb
+          pcb_image: true
+
+      - name: Upload Images
+        uses: actions/upload-artifact@v4
+        with:
+          name: images
+          path: ${{ github.workspace }}/test/images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kicad/kicad:nightly-202409
+FROM kicad/kicad:nightly-202410
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kicad/kicad:8.0
+FROM kicad/kicad:nightly-full
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kicad/kicad:nightly-full
+FROM kicad/kicad:nightly-202409
 
 USER root
 

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,7 @@ inputs:
     default: false
   pcb_image_path:
     description: 'Where to put the top.png and bottom.png'
+    default: 'images'
   
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
   pcb_model:
     description: 'Whether to export the PCB model'
     default: false
-  pcb_gerbers_file:
+  pcb_model_file:
     description: 'Output filename of PCB model'
     default: 'pcb.step'
   

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,9 @@ inputs:
   pcb_model_file:
     description: 'Output filename of PCB model'
     default: 'pcb.step'
+  pcb_model_flags:
+    description: 'Flags to add when exporting STEP files'
+    default: '--no-unspecified --no-dnp --include-tracks  --include-pads  --include-zones'
   
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,12 @@ inputs:
   pcb_gerbers_file:
     description: 'Output filename of Gerbers ZIP'
     default: 'gbr.zip'
-
+  pcb_image:
+    description: 'Whether to render the PCB image'
+    default: false
+  pcb_image_path:
+    description: 'Where to put the top.png and bottom.png'
+  
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,6 @@ inputs:
       - json
       - report
     default: 'report'
-
   kicad_pcb:
     description: 'Path to .kicad_pcb file'
   pcb_drc:
@@ -53,6 +52,12 @@ inputs:
   pcb_image_path:
     description: 'Where to put the top.png and bottom.png'
     default: 'images'
+  pcb_model:
+    description: 'Whether to export the PCB model'
+    default: false
+  pcb_gerbers_file:
+    description: 'Output filename of PCB model'
+    default: 'pcb.step'
   
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,12 +64,12 @@ fi
 
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
 then
-  mkdir -p $INPUT_PCB_IMAGE_PATH
+  mkdir -p "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_IMAGE_PATH"
   kicad-cli pcb render --side top \
-    --output "$INPUT_PCB_IMAGE_PATH/top.png" \
+    --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_IMAGE_PATH/top.png" \
     "$INPUT_KICAD_PCB"
   kicad-cli pcb render --side bottom \
-    --output "$INPUT_PCB_IMAGE_PATH/bottom.png" \
+    --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_IMAGE_PATH/bottom.png" \
     "$INPUT_KICAD_PCB"
   ls images
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,7 +76,7 @@ fi
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_MODEL = "true" ]]
 then
   kicad-cli pcb export step --no-unspecified  --include-tracks  --include-pads  --include-zones --no-dnp --no-optimize-step \
-    --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_MODEL_PATH" \
+    --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_MODEL_FILE" \
     "$INPUT_KICAD_PCB"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 mkdir -p $HOME/.config
 cp -r /home/kicad/.config/kicad $HOME/.config/
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 mkdir -p $HOME/.config
 cp -r /home/kicad/.config/kicad $HOME/.config/
 
@@ -71,7 +69,6 @@ then
   kicad-cli pcb render --side bottom \
     --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_IMAGE_PATH/bottom.png" \
     "$INPUT_KICAD_PCB"
-  ls images
 fi
 
 # Return non-zero exit code for ERC or DRC violations

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,13 +65,13 @@ fi
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
 then
   mkdir -p $INPUT_PCB_IMAGE_PATH
-  kicad-cli pcb export gerbers --side top \
+  kicad-cli pcb render --side top \
     --output "$INPUT_PCB_IMAGE_PATH/top.png" \
     "$INPUT_KICAD_PCB"
   kicad-cli pcb render --side bottom \
     --output "$INPUT_PCB_IMAGE_PATH/bottom.png" \
     "$INPUT_KICAD_PCB"
-  ls
+  ls images
 fi
 
 # Return non-zero exit code for ERC or DRC violations

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,6 +73,13 @@ then
     "$INPUT_KICAD_PCB"
 fi
 
+if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_MODEL = "true" ]]
+then
+  kicad-cli pcb export step --no-unspecified  --include-tracks  --include-pads  --include-zones --no-dnp --no-optimize-step \
+    --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_MODEL_PATH" \
+    "$INPUT_KICAD_PCB"
+fi
+
 # Return non-zero exit code for ERC or DRC violations
 if [[ $erc_violation -gt 0 ]] || [[ $drc_violation -gt 0 ]]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,7 +77,7 @@ fi
 
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_MODEL = "true" ]]
 then
-  kicad-cli pcb export step --no-unspecified  --include-tracks  --include-pads  --include-zones --no-dnp --no-optimize-step \
+  kicad-cli pcb export step $INPUT_PCB_MODEL_FLAGS \
     --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_MODEL_FILE" \
     "$INPUT_KICAD_PCB"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,12 +64,12 @@ fi
 
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
 then
-  mkdir -p $INPUT_IMAGE_PATH
+  mkdir -p $INPUT_PCB_IMAGE_PATH
   kicad-cli pcb export gerbers --side top \
-    --output "$INPUT_IMAGE_PATH/top.png" \
+    --output "$INPUT_PCB_IMAGE_PATH/top.png" \
     "$INPUT_KICAD_PCB"
   kicad-cli pcb render --side bottom \
-    --output "$INPUT_IMAGE_PATH/bottom.png" \
+    --output "$INPUT_PCB_IMAGE_PATH/bottom.png" \
     "$INPUT_KICAD_PCB"
   ls
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 mkdir -p $HOME/.config
 cp -r /home/kicad/.config/kicad $HOME/.config/
 
@@ -69,6 +71,7 @@ then
   kicad-cli pcb render --side bottom \
     --output "$INPUT_IMAGE_PATH/bottom.png" \
     "$INPUT_KICAD_PCB"
+  ls
 fi
 
 # Return non-zero exit code for ERC or DRC violations

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,6 +60,16 @@ then
     "$GERBERS_DIR"/*
 fi
 
+if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
+then
+  kicad-cli pcb export gerbers --side top \
+    --output "$INPUT_IMAGE_PATH/top.png" \
+    "$INPUT_KICAD_PCB"
+  kicad-cli pcb render --side bottom \
+    --output "$INPUT_IMAGE_PATH/bottom.png" \
+    "$INPUT_KICAD_PCB"
+fi
+
 # Return non-zero exit code for ERC or DRC violations
 if [[ $erc_violation -gt 0 ]] || [[ $drc_violation -gt 0 ]]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,6 +62,7 @@ fi
 
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
 then
+  mkdir -p $INPUT_IMAGE_PATH
   kicad-cli pcb export gerbers --side top \
     --output "$INPUT_IMAGE_PATH/top.png" \
     "$INPUT_KICAD_PCB"


### PR DESCRIPTION
Adds raytraced image of PCB top and bottom to output.

Also, please do not merge right now. I'm putting this here so I don't completely forget about it, but right now it depends on KiCad nightly, which broke one of the outputs. By January KiCad 9.0 should release, which should enable this to work on a stable release.