### PR TITLE
Implemented pcb_gerbers_layers parameter for Gerber files generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kicad-action
 
 GitHub Action to automate KiCad tasks, e.g. check ERC/DRC on pull requests or
-generate production files for releases.
+generate production files for releases. Having a lot of improvements this is an upgraded version of [sparkengineering/kicad-action](sparkengineering/kicad-action).
 
 ## Features
 
@@ -82,24 +82,33 @@ jobs:
 See this example working in the action runs of this repository.
 
 ## Configuration
-| Option               | Description                                                      | Default                      |
-|----------------------|------------------------------------------------------------------|------------------------------|
-| `kicad_sch`          | Path to the `.kicad_sch` file                                    |                              |
-| `sch_erc_file`       | Output filename for the ERC report                               |                              |
-| `sch_pdf_file`       | Output filename for the schematic PDF                            |                              |
-| `sch_bom_file`       | Output filename for the BOM                                      |                              |
-| `sch_bom_preset`     | Name of a BOM preset to use                                      |                              |
-| `report_format`      | Format for ERC/DRC reports (`json` or `report`)                  | `report`                     |
-| `kicad_pcb`          | Path to the `.kicad_pcb` file                                    |                              |
-| `pcb_drc_file`       | Output filename for the DRC report                               |                              |
-| `pcb_gerbers_file`   | Output filename for the Gerber archive                           |                              |
-| `pcb_gerbers_layers` | Comma-separated list of PCB layers to include in Gerber output:  |                              |
-|                      | `F.Cu,B.Cu,F.SilkS,B.SilkS,F.Mask,B.Mask,Edge.Cuts`              |                              |
-| `pcb_centroids_file` | Output filename of centroid (component placement)                |                              |
-| `pcb_centroids_format`| Output format to generate centroid files from PCB               | `ascii`                      |
-| `pcb_image_path`     | Output directory for `top.png` and `bottom.png`                  |                              |
-| `pcb_model_file`     | Output filename for the 3D model                                 |                              |
-| `pcb_model_flags`    | Additional flags to use when exporting the STEP model            | See [action.yml](action.yml) |
+| Option                      | Description                                                      | Default                      |
+|-----------------------------|------------------------------------------------------------------|------------------------------|
+| `kicad_sch`                 | Path to the `.kicad_sch` file                                    |                              |
+| `sch_erc_file`              | Output filename for the ERC report                               |                              |
+| `sch_pdf_file`              | Output filename for the schematic PDF                            |                              |
+| `sch_bom_file`              | Output filename for the BOM                                      |                              |
+| `sch_bom_preset`            | Name of a BOM preset to use                                      |                              |
+| `report_format`             | Format for ERC/DRC reports (`json` or `report`)                  | `report`                     |
+| `kicad_pcb`                 | Path to the `.kicad_pcb` file                                    |                              |
+| `pcb_drc_file`              | Output filename for the DRC report                               |                              |
+| `pcb_gerbers_file`          | Output filename for the Gerber archive                           |                              |
+| `pcb_gerbers_layers`        | Comma-separated list of PCB layers to include in Gerber output:  |                              |
+|                             | `F.Cu,B.Cu,F.SilkS,B.SilkS,F.Mask,B.Mask,Edge.Cuts`              |                              |
+| `pcb_centroids_file`        | Output filename of centroid (component placement)                |                              |
+| `pcb_centroids_format`      | Output format to generate centroid files from PCB                | `ascii`                      |
+| `pcb_top_image_file`        | Ouput filename for PCB top view                                  |                              |
+| `pcb_top_image_zoom`        | Ouput zoom for PCB top view (e.g. 1.8)                           |                              |
+| `pcb_top_image_width`       | Ouput image file width for PCB top view                          |                              |
+| `pcb_top_image_height`      | Ouput image file height for PCB top view                         |                              |
+| `pcb_top_image_quality`     | Render quality. Options: basic, high, user [nargs=0..1]          |                              |
+| `pcb_bottom_image_file`     | Ouput filename for PCB bottom view                               |                              |
+| `pcb_bottom_image_zoom`     | Ouput zoom for PCB bottom view (e.g. 1.8)                        |                              |
+| `pcb_bottom_image_width`    | Ouput image file width for PCB bottom view                       |                              |
+| `pcb_bottom_image_height`   | Ouput image file height for PCB bottom view                      |                              |
+| `pcb_bottom_image_quality`  | Render quality. Options: basic, high, user [nargs=0..1]          |                              |
+| `pcb_model_file`            | Output filename for the 3D model                                 |                              |
+| `pcb_model_flags`           | Additional flags to use when exporting the STEP model            | See [action.yml](action.yml) |
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -83,28 +83,29 @@ See this example working in the action runs of this repository.
 
 ## Configuration
 
-| Option             | Description                                     | Default                      |
-|--------------------|-------------------------------------------------|------------------------------|
-| `kicad_sch`        | Path to `.kicad_sch` file                       |                              |
-| `sch_erc`          | Whether to run ERC on the schematic             | `false`                      |
-| `sch_erc_file`     | Output filename of ERC report                   | `erc.rpt`                    |
-| `sch_pdf`          | Whether to generate PDF from schematic          | `false`                      |
-| `sch_pdf_file`     | Output filename of PDF schematic                | `sch.pdf`                    |
-| `sch_bom`          | Whether to generate BOM from schematic          | `false`                      |
-| `sch_bom_file`     | Output filename of BOM                          | `bom.csv`                    |
-| `sch_bom_preset`   | Name of a BOM preset setting to use             |                              |
-| `report_format`    | ERC/DRC report file format (`json` or `report`) | `report`                     |
-|                    |                                                 |                              |
-| `kicad_pcb`        | Path to `.kicad_pcb` file                       |                              |
-| `pcb_drc`          | Whether to run DRC on the PCB                   | `false`                      |
-| `pcb_drc_file`     | Output filename for DRC report                  | `drc.rpt`                    |
-| `pcb_gerbers`      | Whether to generate Gerbers from PCB            | `false`                      |
-| `pcb_gerbers_file` | Output filename of Gerbers                      | `gbr.zip`                    |
-| `pcb_image`        | Whether to render the PCB image                 | `false`                      |
-| `pcb_image_path`   | Where to put the top.png and bottom.png         | `images`                     |
-| `pcb_model`        | Whether to export the PCB model                 | `false`                      |
-| `pcb_model_file`   | Output filename of PCB model                    | `pcb.step`                   |
-| `pcb_model_flags`  | Flags to add when exporting STEP files          | see [action.yml](action.yml) |
+| Option               | Description                                     | Default                      |
+|----------------------|-------------------------------------------------|------------------------------|
+| `kicad_sch`          | Path to `.kicad_sch` file                       |                              |
+| `sch_erc`            | Whether to run ERC on the schematic             | `false`                      |
+| `sch_erc_file`       | Output filename of ERC report                   | `erc.rpt`                    |
+| `sch_pdf`            | Whether to generate PDF from schematic          | `false`                      |
+| `sch_pdf_file`       | Output filename of PDF schematic                | `sch.pdf`                    |
+| `sch_bom`            | Whether to generate BOM from schematic          | `false`                      |
+| `sch_bom_file`       | Output filename of BOM                          | `bom.csv`                    |
+| `sch_bom_preset`     | Name of a BOM preset setting to use             |                              |
+| `report_format`      | ERC/DRC report file format (`json` or `report`) | `report`                     |
+|                      |                                                 |                              |
+| `kicad_pcb`          | Path to `.kicad_pcb` file                       |                              |
+| `pcb_drc`            | Whether to run DRC on the PCB                   | `false`                      |
+| `pcb_drc_file`       | Output filename for DRC report                  | `drc.rpt`                    |
+| `pcb_gerbers`        | Whether to generate Gerbers from PCB            | `false`                      |
+| `pcb_gerbers_file`   | Output filename of Gerbers                      | `gbr.zip`                    |
+| `pcb_gerbers_layers` | Output layers to generate from PCB              |                              |
+| `pcb_image`          | Whether to render the PCB image                 | `false`                      |
+| `pcb_image_path`     | Where to put the top.png and bottom.png         | `images`                     |
+| `pcb_model`          | Whether to export the PCB model                 | `false`                      |
+| `pcb_model_file`     | Output filename of PCB model                    | `pcb.step`                   |
+| `pcb_model_flags`    | Flags to add when exporting STEP files          | see [action.yml](action.yml) |
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ jobs:
 See this example working in the action runs of this repository.
 
 ## Configuration
-
 | Option               | Description                                                      | Default                      |
 |----------------------|------------------------------------------------------------------|------------------------------|
 | `kicad_sch`          | Path to the `.kicad_sch` file                                    |                              |
@@ -102,6 +101,9 @@ See this example working in the action runs of this repository.
 | `pcb_gerbers_file`   | Output filename for the Gerber archive                           | `gbr.zip`                    |
 | `pcb_gerbers_layers` | Comma-separated list of PCB layers to include in Gerber output:  |                              |
 |                      | `F.Cu,B.Cu,F.SilkS,B.SilkS,F.Mask,B.Mask,Edge.Cuts`              |                              |
+| `pcb_centroids`      | Whether to generate centroid (component placement) files from PCB| `false`                      |
+| `pcb_centroids_file` | Output filename of centroid (component placement)                | `cnt.pos`                    |
+| `pcb_centroids_format`| Output format to generate centroid files from PCB               | `ascii`                      |
 | `pcb_image`          | Whether to render top and bottom PCB images                      | `false`                      |
 | `pcb_image_path`     | Output directory for `top.png` and `bottom.png`                  | `images`                     |
 | `pcb_model`          | Whether to export a 3D model of the PCB                          | `false`                      |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ See this example working in the action runs of this repository.
 - [ ] Add support for more configuration options, e.g. BOM format
 - [ ] Add a way to specify KiCad version to use
 - [ ] Better detect if steps of this action fail
-- [ ] Find a better way to enforce the default output files extensions depending on the format requesed
+- [ ] Find a better way to enforce the default output files extensions depending on the format requested
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,33 +83,34 @@ See this example working in the action runs of this repository.
 
 ## Configuration
 
-| Option               | Description                                     | Default                      |
-|----------------------|-------------------------------------------------|------------------------------|
-| `kicad_sch`          | Path to `.kicad_sch` file                       |                              |
-| `sch_erc`            | Whether to run ERC on the schematic             | `false`                      |
-| `sch_erc_file`       | Output filename of ERC report                   | `erc.rpt`                    |
-| `sch_pdf`            | Whether to generate PDF from schematic          | `false`                      |
-| `sch_pdf_file`       | Output filename of PDF schematic                | `sch.pdf`                    |
-| `sch_bom`            | Whether to generate BOM from schematic          | `false`                      |
-| `sch_bom_file`       | Output filename of BOM                          | `bom.csv`                    |
-| `sch_bom_preset`     | Name of a BOM preset setting to use             |                              |
-| `report_format`      | ERC/DRC report file format (`json` or `report`) | `report`                     |
-|                      |                                                 |                              |
-| `kicad_pcb`          | Path to `.kicad_pcb` file                       |                              |
-| `pcb_drc`            | Whether to run DRC on the PCB                   | `false`                      |
-| `pcb_drc_file`       | Output filename for DRC report                  | `drc.rpt`                    |
-| `pcb_gerbers`        | Whether to generate Gerbers from PCB            | `false`                      |
-| `pcb_gerbers_file`   | Output filename of Gerbers                      | `gbr.zip`                    |
-| `pcb_gerbers_layers` | Output layers to generate from PCB              |                              |
-| `pcb_image`          | Whether to render the PCB image                 | `false`                      |
-| `pcb_image_path`     | Where to put the top.png and bottom.png         | `images`                     |
-| `pcb_model`          | Whether to export the PCB model                 | `false`                      |
-| `pcb_model_file`     | Output filename of PCB model                    | `pcb.step`                   |
-| `pcb_model_flags`    | Flags to add when exporting STEP files          | see [action.yml](action.yml) |
+| Option               | Description                                                      | Default                      |
+|----------------------|------------------------------------------------------------------|------------------------------|
+| `kicad_sch`          | Path to the `.kicad_sch` file                                    |                              |
+| `sch_erc`            | Whether to run ERC (Electrical Rules Check) on the schematic     | `false`                      |
+| `sch_erc_file`       | Output filename for the ERC report                               | `erc.rpt`                    |
+| `sch_pdf`            | Whether to generate a PDF from the schematic                     | `false`                      |
+| `sch_pdf_file`       | Output filename for the schematic PDF                            | `sch.pdf`                    |
+| `sch_bom`            | Whether to generate a BOM (Bill of Materials) from the schematic | `false`                      |
+| `sch_bom_file`       | Output filename for the BOM                                      | `bom.csv`                    |
+| `sch_bom_preset`     | Name of a BOM preset to use                                      |                              |
+| `report_format`      | Format for ERC/DRC reports (`json` or `report`)                  | `report`                     |
+|                      |                                                                  |                              |
+| `kicad_pcb`          | Path to the `.kicad_pcb` file                                    |                              |
+| `pcb_drc`            | Whether to run DRC (Design Rules Check) on the PCB               | `false`                      |
+| `pcb_drc_file`       | Output filename for the DRC report                               | `drc.rpt`                    |
+| `pcb_gerbers`        | Whether to generate Gerber files from the PCB                    | `false`                      |
+| `pcb_gerbers_file`   | Output filename for the Gerber archive                           | `gbr.zip`                    |
+| `pcb_gerbers_layers` | Comma-separated list of PCB layers to include in Gerber output:  |                              |
+|                      | `F.Cu,B.Cu,F.SilkS,B.SilkS,F.Mask,B.Mask,Edge.Cuts`              |                              |
+| `pcb_image`          | Whether to render top and bottom PCB images                      | `false`                      |
+| `pcb_image_path`     | Output directory for `top.png` and `bottom.png`                  | `images`                     |
+| `pcb_model`          | Whether to export a 3D model of the PCB                          | `false`                      |
+| `pcb_model_file`     | Output filename for the 3D model                                 | `pcb.step`                   |
+| `pcb_model_flags`    | Additional flags to use when exporting the STEP model            | See [action.yml](action.yml) |
 
 ## Roadmap
 
-- [ ] Add support for more configuration options, e.g. BOM format or Gerber layers
+- [ ] Add support for more configuration options, e.g. BOM format
 - [ ] Add a way to specify KiCad version to use
 - [ ] Better detect if steps of this action fail
 - [ ] Find a better way to enforce the default output files extensions depending on the format requesed

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ jobs:
         if: '!cancelled()'
         with:
           kicad_sch: my-project.kicad_sch
-          sch_pdf: true # Generate PDF
-          sch_bom: true # Generate BOM
+          sch_pdf_file: sch.pdf # Generate PDF
+          sch_bom_file: bom.csv # Generate BOM
           kicad_pcb: my-project.kicad_pcb
-          pcb_gerbers: true # Generate Gerbers
+          pcb_gerbers_file: gbr.zip # Generate Gerbers
 
       # Upload production files only if generation succeeded
       - name: Upload production files
@@ -52,7 +52,7 @@ jobs:
         if: '!cancelled()'
         with:
           kicad_sch: my-project.kicad_sch
-          sch_erc: true
+          sch_erc: erc.rpt
 
       - name: Run KiCad DRC
         id: drc
@@ -60,7 +60,7 @@ jobs:
         if: '!cancelled()'
         with:
           kicad_pcb: my-project.kicad_pcb
-          pcb_drc: true
+          pcb_drc_file: drc.rpt
 
       # Upload ERC report only if ERC failed
       - name: Upload ERC report
@@ -85,29 +85,20 @@ See this example working in the action runs of this repository.
 | Option               | Description                                                      | Default                      |
 |----------------------|------------------------------------------------------------------|------------------------------|
 | `kicad_sch`          | Path to the `.kicad_sch` file                                    |                              |
-| `sch_erc`            | Whether to run ERC (Electrical Rules Check) on the schematic     | `false`                      |
-| `sch_erc_file`       | Output filename for the ERC report                               | `erc.rpt`                    |
-| `sch_pdf`            | Whether to generate a PDF from the schematic                     | `false`                      |
-| `sch_pdf_file`       | Output filename for the schematic PDF                            | `sch.pdf`                    |
-| `sch_bom`            | Whether to generate a BOM (Bill of Materials) from the schematic | `false`                      |
-| `sch_bom_file`       | Output filename for the BOM                                      | `bom.csv`                    |
+| `sch_erc_file`       | Output filename for the ERC report                               |                              |
+| `sch_pdf_file`       | Output filename for the schematic PDF                            |                              |
+| `sch_bom_file`       | Output filename for the BOM                                      |                              |
 | `sch_bom_preset`     | Name of a BOM preset to use                                      |                              |
 | `report_format`      | Format for ERC/DRC reports (`json` or `report`)                  | `report`                     |
-|                      |                                                                  |                              |
 | `kicad_pcb`          | Path to the `.kicad_pcb` file                                    |                              |
-| `pcb_drc`            | Whether to run DRC (Design Rules Check) on the PCB               | `false`                      |
-| `pcb_drc_file`       | Output filename for the DRC report                               | `drc.rpt`                    |
-| `pcb_gerbers`        | Whether to generate Gerber files from the PCB                    | `false`                      |
-| `pcb_gerbers_file`   | Output filename for the Gerber archive                           | `gbr.zip`                    |
+| `pcb_drc_file`       | Output filename for the DRC report                               |                              |
+| `pcb_gerbers_file`   | Output filename for the Gerber archive                           |                              |
 | `pcb_gerbers_layers` | Comma-separated list of PCB layers to include in Gerber output:  |                              |
 |                      | `F.Cu,B.Cu,F.SilkS,B.SilkS,F.Mask,B.Mask,Edge.Cuts`              |                              |
-| `pcb_centroids`      | Whether to generate centroid (component placement) files from PCB| `false`                      |
-| `pcb_centroids_file` | Output filename of centroid (component placement)                | `cnt.pos`                    |
+| `pcb_centroids_file` | Output filename of centroid (component placement)                |                              |
 | `pcb_centroids_format`| Output format to generate centroid files from PCB               | `ascii`                      |
-| `pcb_image`          | Whether to render top and bottom PCB images                      | `false`                      |
-| `pcb_image_path`     | Output directory for `top.png` and `bottom.png`                  | `images`                     |
-| `pcb_model`          | Whether to export a 3D model of the PCB                          | `false`                      |
-| `pcb_model_file`     | Output filename for the 3D model                                 | `pcb.step`                   |
+| `pcb_image_path`     | Output directory for `top.png` and `bottom.png`                  |                              |
+| `pcb_model_file`     | Output filename for the 3D model                                 |                              |
 | `pcb_model_flags`    | Additional flags to use when exporting the STEP model            | See [action.yml](action.yml) |
 
 ## Roadmap

--- a/action.yml
+++ b/action.yml
@@ -4,27 +4,14 @@ description: 'Automate KiCad tasks, e.g. check ERC/DRC on pull requests or gener
 inputs:
   kicad_sch:
     description: 'Path to .kicad_sch file'
-  sch_erc:
-    description: 'Whether to run ERC on the schematic'
-    default: false
   sch_erc_file:
     description: 'Output filename of ERC report'
-    default: 'erc.rpt'
-  sch_pdf:
-    description: 'Whether to generate PDF from schematic'
-    default: false
   sch_pdf_file:
     description: 'Output filename of PDF schematic'
-    default: 'sch.pdf'
-  sch_bom:
-    description: 'Whether to generate BOM from schematic'
-    default: false
   sch_bom_file:
     description: 'Output filename of BOM'
-    default: 'bom.csv'
   sch_bom_preset:
     description: 'Name of a BOM preset setting to use'
-    default: ''
   report_format:
     description: 'ERC and DRC report files format'
     type: choice
@@ -34,42 +21,21 @@ inputs:
     default: 'report'
   kicad_pcb:
     description: 'Path to .kicad_pcb file'
-  pcb_drc:
-    description: 'Whether to run DRC on the PCB'
-    default: false
   pcb_drc_file:
     description: 'Output filename for DRC report'
-    default: 'drc.rpt'
-  pcb_gerbers:
-    description: 'Whether to generate Gerbers from PCB'
-    default: false
   pcb_gerbers_file:
     description: 'Output filename of Gerbers ZIP'
-    default: 'gbr.zip'
   pcb_gerbers_layers:
     description: 'Output layers to generate from PCB'
-    default: ''
-  pcb_centroids:
-    description: 'Whether to generate centroid (component placement) files from PCB'
-    default: false
   pcb_centroids_file:
     description: 'Output filename of centroid (component placement)'
-    default: 'cnt.pos'
   pcb_centroids_format:
     description: 'Output format to generate centroid (component placement) files from PCB'
     default: 'ascii'
-  pcb_image:
-    description: 'Whether to render the PCB image'
-    default: false
   pcb_image_path:
     description: 'Where to put the top.png and bottom.png'
-    default: 'images'
-  pcb_model:
-    description: 'Whether to export the PCB model'
-    default: false
   pcb_model_file:
     description: 'Output filename of PCB model'
-    default: 'pcb.step'
   pcb_model_flags:
     description: 'Flags to add when exporting STEP files'
     default: '--no-unspecified --no-dnp --include-tracks  --include-pads  --include-zones'

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,26 @@ inputs:
   pcb_centroids_format:
     description: 'Output format to generate centroid (component placement) files from PCB'
     default: 'ascii'
-  pcb_image_path:
-    description: 'Where to put the top.png and bottom.png'
+  pcb_top_image_file:
+    description: 'Ouput filename for PCB top view'
+  pcb_top_image_zoom:
+    description: 'Ouput zoom for PCB top view'
+  pcb_top_image_quality:
+    description: 'Ouput image file render quality. Options: basic, high, user [nargs=0..1]'
+  pcb_top_image_width:
+    description: 'Ouput image file width for PCB top view'
+  pcb_top_image_height:
+    description: 'Ouput image file height for PCB top view'
+  pcb_bottom_image_file:
+    description: 'Ouput filename for PCB bottom view'
+  pcb_bottom_image_zoom:
+    description: 'Ouput zoom for PCB bottom view'
+  pcb_bottom_image_width:
+    description: 'Ouput image file width for PCB bottom view'
+  pcb_bottom_image_height:
+    description: 'Ouput image file height for PCB top view'
+  pcb_bottom_image_quality:
+    description: 'Ouput image file render quality. Options: basic, high, user [nargs=0..1]'
   pcb_model_file:
     description: 'Output filename of PCB model'
   pcb_model_flags:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'KiCad Action'
+name: 'KiCad command line Action'
 description: 'Automate KiCad tasks, e.g. check ERC/DRC on pull requests or generate production files for releases'
 
 inputs:

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,15 @@ inputs:
   pcb_gerbers_layers:
     description: 'Output layers to generate from PCB'
     default: ''
+  pcb_centroids:
+    description: 'Whether to generate centroid (component placement) files from PCB'
+    default: false
+  pcb_centroids_file:
+    description: 'Output filename of centroid (component placement)'
+    default: 'cnt.pos'
+  pcb_centroids_format:
+    description: 'Output format to generate centroid (component placement) files from PCB'
+    default: 'ascii'
   pcb_image:
     description: 'Whether to render the PCB image'
     default: false

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
   pcb_gerbers_file:
     description: 'Output filename of Gerbers ZIP'
     default: 'gbr.zip'
+  pcb_gerbers_layers:
+    description: 'Output layers to generate from PCB'
+    default: ''
   pcb_image:
     description: 'Whether to render the PCB image'
     default: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ then
   kicad-cli sch erc \
     --output "`dirname $INPUT_KICAD_SCH`/$INPUT_SCH_ERC_FILE" \
     --format $INPUT_REPORT_FORMAT \
+    --severity-error \
     --exit-code-violations \
     "$INPUT_KICAD_SCH"
   erc_violation=$?
@@ -42,6 +43,7 @@ then
   kicad-cli pcb drc \
     --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_DRC_FILE" \
     --format $INPUT_REPORT_FORMAT \
+    --severity-error \
     --exit-code-violations \
     "$INPUT_KICAD_PCB"
   drc_violation=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,9 +51,16 @@ fi
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_GERBERS = "true" ]]
 then
   GERBERS_DIR=`mktemp -d`
-  kicad-cli pcb export gerbers \
-    --output "$GERBERS_DIR/" \
-    "$INPUT_KICAD_PCB"
+  if [[ -n $INPUT_PCB_GERBERS_LAYERS ]]; then
+    kicad-cli pcb export gerbers \
+      --layers "$INPUT_PCB_GERBERS_LAYERS" \
+      --output "$GERBERS_DIR/" \
+      "$INPUT_KICAD_PCB"
+  else
+    kicad-cli pcb export gerbers \
+      --output "$GERBERS_DIR/" \
+      "$INPUT_KICAD_PCB"
+  fi
   kicad-cli pcb export drill \
     --output "$GERBERS_DIR/" \
     "$INPUT_KICAD_PCB"
@@ -61,6 +68,7 @@ then
     "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_GERBERS_FILE" \
     "$GERBERS_DIR"/*
 fi
+
 
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,15 +82,54 @@ then
     "$INPUT_KICAD_PCB"
 fi
 
-if [[ -n $INPUT_KICAD_PCB ]] && [[ -n $INPUT_PCB_IMAGE_PATH ]]
-then
-  mkdir -p "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_IMAGE_PATH"
-  kicad-cli pcb render --side top \
-    --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_IMAGE_PATH/top.png" \
-    "$INPUT_KICAD_PCB"
-  kicad-cli pcb render --side bottom \
-    --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_IMAGE_PATH/bottom.png" \
-    "$INPUT_KICAD_PCB"
+if [[ -n $INPUT_KICAD_PCB ]] && [[ -n $INPUT_PCB_TOP_IMAGE_FILE ]]; then
+  mkdir -p "`dirname $INPUT_KICAD_PCB`/`dirname $INPUT_PCB_TOP_IMAGE_FILE`"
+  
+  CMD_TOP=(kicad-cli pcb render --side top)
+  CMD_TOP+=(--output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_TOP_IMAGE_FILE")
+  
+  if [[ -n $INPUT_PCB_TOP_IMAGE_ZOOM ]]; then
+    CMD_TOP+=(--zoom "$INPUT_PCB_TOP_IMAGE_ZOOM")
+  fi
+  
+  if [[ -n $INPUT_PCB_TOP_IMAGE_WIDTH ]]; then
+    CMD_TOP+=(--width "$INPUT_PCB_TOP_IMAGE_WIDTH")
+  fi
+
+  if [[ -n $INPUT_PCB_TOP_IMAGE_HEIGHT ]]; then
+    CMD_TOP+=(--height "$INPUT_PCB_TOP_IMAGE_HEIGHT")
+  fi
+  
+  if [[ -n $INPUT_PCB_TOP_IMAGE_QUALITY ]]; then
+    CMD_TOP+=(--quality "$INPUT_PCB_TOP_IMAGE_QUALITY")
+  fi
+  
+  "${CMD_TOP[@]}" "$INPUT_KICAD_PCB"
+fi
+
+if [[ -n $INPUT_KICAD_PCB ]] && [[ -n $INPUT_PCB_BOTTOM_IMAGE_FILE ]]; then
+  mkdir -p "`dirname $INPUT_KICAD_PCB`/`dirname $INPUT_PCB_BOTTOM_IMAGE_FILE`"
+  
+  CMD_BOTTOM=(kicad-cli pcb render --side bottom)
+  CMD_BOTTOM+=(--output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_BOTTOM_IMAGE_FILE")
+  
+  if [[ -n $INPUT_PCB_BOTTOM_IMAGE_ZOOM ]]; then
+    CMD_BOTTOM+=(--zoom "$INPUT_PCB_BOTTOM_IMAGE_ZOOM")
+  fi
+  
+  if [[ -n $INPUT_PCB_BOTTOM_IMAGE_WIDTH ]]; then
+    CMD_BOTTOM+=(--width "$INPUT_PCB_BOTTOM_IMAGE_WIDTH")
+  fi
+
+  if [[ -n $INPUT_PCB_BOTTOM_IMAGE_HEIGHT ]]; then
+    CMD_BOTTOM+=(--height "$INPUT_PCB_BOTTOM_IMAGE_HEIGHT")
+  fi
+
+  if [[ -n $INPUT_PCB_BOTTOM_IMAGE_QUALITY ]]; then
+    CMD_BOTTOM+=(--quality "$INPUT_PCB_BOTTOM_IMAGE_QUALITY")
+  fi
+
+  "${CMD_BOTTOM[@]}" "$INPUT_KICAD_PCB"
 fi
 
 if [[ -n $INPUT_KICAD_PCB ]] && [[ -n $INPUT_PCB_MODEL_FILE ]]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ erc_violation=0 # ERC exit code
 drc_violation=0 # DRC exit code
 
 # Run ERC if requested
-if [[ -n $INPUT_KICAD_SCH ]] && [[ $INPUT_SCH_ERC = "true" ]]
+if [[ -n $INPUT_KICAD_SCH ]] && [[ -n $INPUT_SCH_ERC_FILE ]]
 then
   kicad-cli sch erc \
     --output "`dirname $INPUT_KICAD_SCH`/$INPUT_SCH_ERC_FILE" \
@@ -21,7 +21,7 @@ then
 fi
 
 # Export schematic PDF if requested
-if [[ -n $INPUT_KICAD_SCH ]] && [[ $INPUT_SCH_PDF = "true" ]]
+if [[ -n $INPUT_KICAD_SCH ]] && [[ -n $INPUT_SCH_PDF_FILE ]]
 then
   kicad-cli sch export pdf \
     --output "`dirname $INPUT_KICAD_SCH`/$INPUT_SCH_PDF_FILE" \
@@ -29,7 +29,7 @@ then
 fi
 
 # Export schematic BOM if requested
-if [[ -n $INPUT_KICAD_SCH ]] && [[ $INPUT_SCH_BOM = "true" ]]
+if [[ -n $INPUT_KICAD_SCH ]] && [[ -n $INPUT_SCH_BOM_FILE ]]
 then
   kicad-cli sch export bom \
     --output "`dirname $INPUT_KICAD_SCH`/$INPUT_SCH_BOM_FILE" \
@@ -38,7 +38,7 @@ then
 fi
 
 # Run DRC if requested
-if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_DRC = "true" ]]
+if [[ -n $INPUT_KICAD_PCB ]] && [[ -n $INPUT_PCB_DRC_FILE ]]
 then
   kicad-cli pcb drc \
     --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_DRC_FILE" \
@@ -50,7 +50,7 @@ then
 fi
 
 # Export Gerbers if requested
-if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_GERBERS = "true" ]]
+if [[ -n $INPUT_KICAD_PCB ]] && [[ -n $INPUT_PCB_GERBERS_FILE ]]
 then
   GERBERS_DIR=`mktemp -d`
   if [[ -n $INPUT_PCB_GERBERS_LAYERS ]]; then
@@ -72,7 +72,7 @@ then
 fi
 
 # Export centroid (placement) file if requested
-if [[ -n "$INPUT_KICAD_PCB" && "$INPUT_PCB_CENTROIDS" == "true" ]]
+if [[ -n "$INPUT_KICAD_PCB" ]] && [[ -n "$INPUT_PCB_CENTROIDS_FILE" ]]
 then
   echo "Exporting centroid (placement) file to $INPUT_PCB_CENTROIDS_FILE..."
   kicad-cli pcb export pos \
@@ -82,7 +82,7 @@ then
     "$INPUT_KICAD_PCB"
 fi
 
-if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
+if [[ -n $INPUT_KICAD_PCB ]] && [[ -n $INPUT_PCB_IMAGE_PATH ]]
 then
   mkdir -p "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_IMAGE_PATH"
   kicad-cli pcb render --side top \
@@ -93,7 +93,7 @@ then
     "$INPUT_KICAD_PCB"
 fi
 
-if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_MODEL = "true" ]]
+if [[ -n $INPUT_KICAD_PCB ]] && [[ -n $INPUT_PCB_MODEL_FILE ]]
 then
   kicad-cli pcb export step $INPUT_PCB_MODEL_FLAGS \
     --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_MODEL_FILE" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,6 +69,16 @@ then
     "$GERBERS_DIR"/*
 fi
 
+# Export centroid (placement) file if requested
+if [[ -n "$INPUT_KICAD_PCB" && "$INPUT_PCB_CENTROIDS" == "true" ]]
+then
+  echo "Exporting centroid (placement) file to $INPUT_PCB_CENTROIDS_FILE..."
+  kicad-cli pcb export pos \
+    --format "$INPUT_PCB_CENTROIDS_FORMAT" \
+    --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_CENTROIDS_FILE" \
+    --units mm \
+    "$INPUT_KICAD_PCB"
+fi
 
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
 then


### PR DESCRIPTION
This parameter has an empty default value. All layers are generated when no value assigned.

Example of usage:

```yml
      - name: Run KiCad export
        uses: vikulin/kicad-action@main
        with:
          kicad_sch: gamma-spectrometer.kicad_sch
          sch_pdf: true # Generate PDF
          sch_pdf_file: docs/open-gamma-kit-${{ github.ref_name }}.pdf
          sch_bom: false
          kicad_pcb: gamma-spectrometer.kicad_pcb
          pcb_gerbers: true # Generate Gerbers
          pcb_gerbers_file: build/open-gamma-kit-gerber-files-${{ github.ref_name }}.zip
          pcb_gerbers_layers: F.Cu,B.Cu,F.SilkS,B.SilkS,F.Mask,B.Mask,Edge.Cuts 
```