### PR TITLE
Add Centroid File Generation Options for PCB Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,28 +83,29 @@ See this example working in the action runs of this repository.
 
 ## Configuration
 
-| Option             | Description                                     | Default                      |
-|--------------------|-------------------------------------------------|------------------------------|
-| `kicad_sch`        | Path to `.kicad_sch` file                       |                              |
-| `sch_erc`          | Whether to run ERC on the schematic             | `false`                      |
-| `sch_erc_file`     | Output filename of ERC report                   | `erc.rpt`                    |
-| `sch_pdf`          | Whether to generate PDF from schematic          | `false`                      |
-| `sch_pdf_file`     | Output filename of PDF schematic                | `sch.pdf`                    |
-| `sch_bom`          | Whether to generate BOM from schematic          | `false`                      |
-| `sch_bom_file`     | Output filename of BOM                          | `bom.csv`                    |
-| `sch_bom_preset`   | Name of a BOM preset setting to use             |                              |
-| `report_format`    | ERC/DRC report file format (`json` or `report`) | `report`                     |
-|                    |                                                 |                              |
-| `kicad_pcb`        | Path to `.kicad_pcb` file                       |                              |
-| `pcb_drc`          | Whether to run DRC on the PCB                   | `false`                      |
-| `pcb_drc_file`     | Output filename for DRC report                  | `drc.rpt`                    |
-| `pcb_gerbers`      | Whether to generate Gerbers from PCB            | `false`                      |
-| `pcb_gerbers_file` | Output filename of Gerbers                      | `gbr.zip`                    |
-| `pcb_image`        | Whether to render the PCB image                 | `false`                      |
-| `pcb_image_path`   | Where to put the top.png and bottom.png         | `images`                     |
-| `pcb_model`        | Whether to export the PCB model                 | `false`                      |
-| `pcb_model_file`   | Output filename of PCB model                    | `pcb.step`                   |
-| `pcb_model_flags`  | Flags to add when exporting STEP files          | see [action.yml](action.yml) |
+| Option               | Description                                     | Default                      |
+|----------------------|-------------------------------------------------|------------------------------|
+| `kicad_sch`          | Path to `.kicad_sch` file                       |                              |
+| `sch_erc`            | Whether to run ERC on the schematic             | `false`                      |
+| `sch_erc_file`       | Output filename of ERC report                   | `erc.rpt`                    |
+| `sch_pdf`            | Whether to generate PDF from schematic          | `false`                      |
+| `sch_pdf_file`       | Output filename of PDF schematic                | `sch.pdf`                    |
+| `sch_bom`            | Whether to generate BOM from schematic          | `false`                      |
+| `sch_bom_file`       | Output filename of BOM                          | `bom.csv`                    |
+| `sch_bom_preset`     | Name of a BOM preset setting to use             |                              |
+| `report_format`      | ERC/DRC report file format (`json` or `report`) | `report`                     |
+|                      |                                                 |                              |
+| `kicad_pcb`          | Path to `.kicad_pcb` file                       |                              |
+| `pcb_drc`            | Whether to run DRC on the PCB                   | `false`                      |
+| `pcb_drc_file`       | Output filename for DRC report                  | `drc.rpt`                    |
+| `pcb_gerbers`        | Whether to generate Gerbers from PCB            | `false`                      |
+| `pcb_gerbers_file`   | Output filename of Gerbers                      | `gbr.zip`                    |
+| `pcb_gerbers_layers` | Output layers to generate from PCB              |                              |
+| `pcb_image`          | Whether to render the PCB image                 | `false`                      |
+| `pcb_image_path`     | Where to put the top.png and bottom.png         | `images`                     |
+| `pcb_model`          | Whether to export the PCB model                 | `false`                      |
+| `pcb_model_file`     | Output filename of PCB model                    | `pcb.step`                   |
+| `pcb_model_flags`    | Flags to add when exporting STEP files          | see [action.yml](action.yml) |
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ jobs:
 See this example working in the action runs of this repository.
 
 ## Configuration
-
 | Option               | Description                                                      | Default                      |
 |----------------------|------------------------------------------------------------------|------------------------------|
 | `kicad_sch`          | Path to the `.kicad_sch` file                                    |                              |
@@ -102,6 +101,9 @@ See this example working in the action runs of this repository.
 | `pcb_gerbers_file`   | Output filename for the Gerber archive                           | `gbr.zip`                    |
 | `pcb_gerbers_layers` | Comma-separated list of PCB layers to include in Gerber output:  |                              |
 |                      | `F.Cu,B.Cu,F.SilkS,B.SilkS,F.Mask,B.Mask,Edge.Cuts`              |                              |
+| `pcb_centroids`      | Whether to generate centroid (component placement) files from PCB| `false`                      |
+| `pcb_centroids_file` | Output filename of centroid (component placement)                | `cnt.pos`                    |
+| `pcb_centroids_format`| Output format to generate centroid files from PCB               | `ascii`                      |
 | `pcb_image`          | Whether to render top and bottom PCB images                      | `false`                      |
 | `pcb_image_path`     | Output directory for `top.png` and `bottom.png`                  | `images`                     |
 | `pcb_model`          | Whether to export a 3D model of the PCB                          | `false`                      |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ See this example working in the action runs of this repository.
 - [ ] Add support for more configuration options, e.g. BOM format
 - [ ] Add a way to specify KiCad version to use
 - [ ] Better detect if steps of this action fail
-- [ ] Find a better way to enforce the default output files extensions depending on the format requesed
+- [ ] Find a better way to enforce the default output files extensions depending on the format requested
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,33 +83,34 @@ See this example working in the action runs of this repository.
 
 ## Configuration
 
-| Option               | Description                                     | Default                      |
-|----------------------|-------------------------------------------------|------------------------------|
-| `kicad_sch`          | Path to `.kicad_sch` file                       |                              |
-| `sch_erc`            | Whether to run ERC on the schematic             | `false`                      |
-| `sch_erc_file`       | Output filename of ERC report                   | `erc.rpt`                    |
-| `sch_pdf`            | Whether to generate PDF from schematic          | `false`                      |
-| `sch_pdf_file`       | Output filename of PDF schematic                | `sch.pdf`                    |
-| `sch_bom`            | Whether to generate BOM from schematic          | `false`                      |
-| `sch_bom_file`       | Output filename of BOM                          | `bom.csv`                    |
-| `sch_bom_preset`     | Name of a BOM preset setting to use             |                              |
-| `report_format`      | ERC/DRC report file format (`json` or `report`) | `report`                     |
-|                      |                                                 |                              |
-| `kicad_pcb`          | Path to `.kicad_pcb` file                       |                              |
-| `pcb_drc`            | Whether to run DRC on the PCB                   | `false`                      |
-| `pcb_drc_file`       | Output filename for DRC report                  | `drc.rpt`                    |
-| `pcb_gerbers`        | Whether to generate Gerbers from PCB            | `false`                      |
-| `pcb_gerbers_file`   | Output filename of Gerbers                      | `gbr.zip`                    |
-| `pcb_gerbers_layers` | Output layers to generate from PCB              |                              |
-| `pcb_image`          | Whether to render the PCB image                 | `false`                      |
-| `pcb_image_path`     | Where to put the top.png and bottom.png         | `images`                     |
-| `pcb_model`          | Whether to export the PCB model                 | `false`                      |
-| `pcb_model_file`     | Output filename of PCB model                    | `pcb.step`                   |
-| `pcb_model_flags`    | Flags to add when exporting STEP files          | see [action.yml](action.yml) |
+| Option               | Description                                                      | Default                      |
+|----------------------|------------------------------------------------------------------|------------------------------|
+| `kicad_sch`          | Path to the `.kicad_sch` file                                    |                              |
+| `sch_erc`            | Whether to run ERC (Electrical Rules Check) on the schematic     | `false`                      |
+| `sch_erc_file`       | Output filename for the ERC report                               | `erc.rpt`                    |
+| `sch_pdf`            | Whether to generate a PDF from the schematic                     | `false`                      |
+| `sch_pdf_file`       | Output filename for the schematic PDF                            | `sch.pdf`                    |
+| `sch_bom`            | Whether to generate a BOM (Bill of Materials) from the schematic | `false`                      |
+| `sch_bom_file`       | Output filename for the BOM                                      | `bom.csv`                    |
+| `sch_bom_preset`     | Name of a BOM preset to use                                      |                              |
+| `report_format`      | Format for ERC/DRC reports (`json` or `report`)                  | `report`                     |
+|                      |                                                                  |                              |
+| `kicad_pcb`          | Path to the `.kicad_pcb` file                                    |                              |
+| `pcb_drc`            | Whether to run DRC (Design Rules Check) on the PCB               | `false`                      |
+| `pcb_drc_file`       | Output filename for the DRC report                               | `drc.rpt`                    |
+| `pcb_gerbers`        | Whether to generate Gerber files from the PCB                    | `false`                      |
+| `pcb_gerbers_file`   | Output filename for the Gerber archive                           | `gbr.zip`                    |
+| `pcb_gerbers_layers` | Comma-separated list of PCB layers to include in Gerber output:  |                              |
+|                      | `F.Cu,B.Cu,F.SilkS,B.SilkS,F.Mask,B.Mask,Edge.Cuts`              |                              |
+| `pcb_image`          | Whether to render top and bottom PCB images                      | `false`                      |
+| `pcb_image_path`     | Output directory for `top.png` and `bottom.png`                  | `images`                     |
+| `pcb_model`          | Whether to export a 3D model of the PCB                          | `false`                      |
+| `pcb_model_file`     | Output filename for the 3D model                                 | `pcb.step`                   |
+| `pcb_model_flags`    | Additional flags to use when exporting the STEP model            | See [action.yml](action.yml) |
 
 ## Roadmap
 
-- [ ] Add support for more configuration options, e.g. BOM format or Gerber layers
+- [ ] Add support for more configuration options, e.g. BOM format
 - [ ] Add a way to specify KiCad version to use
 - [ ] Better detect if steps of this action fail
 - [ ] Find a better way to enforce the default output files extensions depending on the format requesed

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,15 @@ inputs:
   pcb_gerbers_layers:
     description: 'Output layers to generate from PCB'
     default: ''
+  pcb_centroids:
+    description: 'Whether to generate centroid (component placement) files from PCB'
+    default: false
+  pcb_centroids_file:
+    description: 'Output filename of centroid (component placement)'
+    default: 'cnt.pos'
+  pcb_centroids_format:
+    description: 'Output format to generate centroid (component placement) files from PCB'
+    default: 'ascii'
   pcb_image:
     description: 'Whether to render the PCB image'
     default: false

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
   pcb_gerbers_file:
     description: 'Output filename of Gerbers ZIP'
     default: 'gbr.zip'
+  pcb_gerbers_layers:
+    description: 'Output layers to generate from PCB'
+    default: ''
   pcb_image:
     description: 'Whether to render the PCB image'
     default: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ then
   kicad-cli sch erc \
     --output "`dirname $INPUT_KICAD_SCH`/$INPUT_SCH_ERC_FILE" \
     --format $INPUT_REPORT_FORMAT \
+    --severity-error \
     --exit-code-violations \
     "$INPUT_KICAD_SCH"
   erc_violation=$?
@@ -42,6 +43,7 @@ then
   kicad-cli pcb drc \
     --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_DRC_FILE" \
     --format $INPUT_REPORT_FORMAT \
+    --severity-error \
     --exit-code-violations \
     "$INPUT_KICAD_PCB"
   drc_violation=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,9 +51,16 @@ fi
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_GERBERS = "true" ]]
 then
   GERBERS_DIR=`mktemp -d`
-  kicad-cli pcb export gerbers \
-    --output "$GERBERS_DIR/" \
-    "$INPUT_KICAD_PCB"
+  if [[ -n $INPUT_PCB_GERBERS_LAYERS ]]; then
+    kicad-cli pcb export gerbers \
+      --layers "$INPUT_PCB_GERBERS_LAYERS" \
+      --output "$GERBERS_DIR/" \
+      "$INPUT_KICAD_PCB"
+  else
+    kicad-cli pcb export gerbers \
+      --output "$GERBERS_DIR/" \
+      "$INPUT_KICAD_PCB"
+  fi
   kicad-cli pcb export drill \
     --output "$GERBERS_DIR/" \
     "$INPUT_KICAD_PCB"
@@ -61,6 +68,7 @@ then
     "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_GERBERS_FILE" \
     "$GERBERS_DIR"/*
 fi
+
 
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,6 +69,16 @@ then
     "$GERBERS_DIR"/*
 fi
 
+# Export centroid (placement) file if requested
+if [[ -n "$INPUT_KICAD_PCB" && "$INPUT_PCB_CENTROIDS" == "true" ]]
+then
+  echo "Exporting centroid (placement) file to $INPUT_PCB_CENTROIDS_FILE..."
+  kicad-cli pcb export pos \
+    --format "$INPUT_PCB_CENTROIDS_FORMAT" \
+    --output "`dirname $INPUT_KICAD_PCB`/$INPUT_PCB_CENTROIDS_FILE" \
+    --units mm \
+    "$INPUT_KICAD_PCB"
+fi
 
 if [[ -n $INPUT_KICAD_PCB ]] && [[ $INPUT_PCB_IMAGE = "true" ]]
 then


### PR DESCRIPTION
#### Summary

This PR introduces support for generating **centroid (component placement) files** from a KiCad PCB, expanding the PCB export capabilities of the tool. The following new configuration options are added:

* `pcb_centroids`: Enables/disables centroid file generation.
* `pcb_centroids_file`: Sets the output filename for the centroid file (default: `cnt.pos`).
* `pcb_centroids_format`: Specifies the output format (`ascii` by default).

#### Changes

* Updated `action.yml` to include the new inputs.
* Modified the README to document the new options in the configuration table.

#### Motivation

Centroid files are essential for automated pick-and-place processes during PCB assembly. Adding support for their generation simplifies integration into manufacturing workflows.

#### Notes

* Centroid file output currently defaults to `ascii` format. Support for additional formats can be extended in the future.
